### PR TITLE
fix(browser): attach-mode tab selection and capture caveats

### DIFF
--- a/.claude/skills/x-browser-capture/SKILL.md
+++ b/.claude/skills/x-browser-capture/SKILL.md
@@ -20,7 +20,7 @@ Exits 0 when live. URL is resolved automatically from `BUNDLER` in `.env`. Note 
 
 ## Step 2 — Pick capture tier
 
-Use `--attach` only in visible Chrome (match by origin, no navigation) — not in CI. Run `pnpm browser open --url <url>` first. Capture attach: HAR is capture-window only; `trace.zip` may include other tabs; `record-console` needs a URL.
+Attach: visible Chrome only, not CI. Match tab by origin; no navigation. Run `pnpm browser open --url <url>` first.
 
 ### A — `devtools-capture` MCP
 

--- a/.claude/skills/x-browser-capture/SKILL.md
+++ b/.claude/skills/x-browser-capture/SKILL.md
@@ -22,6 +22,8 @@ Exits 0 when live. URL is resolved automatically from `BUNDLER` in `.env`. Note 
 
 Use attach only in visible Chrome to preserve session and tab state — not in CI. Run `pnpm browser open --url <url>` first.
 
+**Attach semantics:** match tab by URL **origin**; when several tabs share an origin, the most recently opened tab is used and brought to the front. Does not navigate. `record-console` with attach requires `url`. `record-trace` attach: HAR is capture-window only; `trace.zip` may include other tabs in the browser context.
+
 ### A — `devtools-capture` MCP
 
 Attach: `attach=true` on the tool.

--- a/.claude/skills/x-browser-capture/SKILL.md
+++ b/.claude/skills/x-browser-capture/SKILL.md
@@ -20,9 +20,7 @@ Exits 0 when live. URL is resolved automatically from `BUNDLER` in `.env`. Note 
 
 ## Step 2 — Pick capture tier
 
-Use attach only in visible Chrome to preserve session and tab state — not in CI. Run `pnpm browser open --url <url>` first.
-
-**Attach semantics:** match tab by URL **origin**; when several tabs share an origin, the most recently opened tab is used and brought to the front. Does not navigate. `record-console` with attach requires `url`. `record-trace` attach: HAR is capture-window only; `trace.zip` may include other tabs in the browser context.
+Use `--attach` only in visible Chrome (match by origin, no navigation) — not in CI. Run `pnpm browser open --url <url>` first. Capture attach: HAR is capture-window only; `trace.zip` may include other tabs; `record-console` needs a URL.
 
 ### A — `devtools-capture` MCP
 
@@ -74,5 +72,3 @@ Artifacts land in `packages/browser-capture/artifacts/<mode>-<timestamp>/`.
 ---
 
 For routine DOM/text verification use the browser-validation skill — never mix tiers.
-
-> Edge-case scenarios (`--attach`, remote URL, SSH tunnel), Storybook URL, artifact formats, and env vars: [`docs/browser-validation.md`](../../../docs/browser-validation.md) · [`packages/browser-capture/README.md`](../../../packages/browser-capture/README.md)

--- a/.claude/skills/x-browser-capture/SKILL.md
+++ b/.claude/skills/x-browser-capture/SKILL.md
@@ -72,3 +72,5 @@ Artifacts land in `packages/browser-capture/artifacts/<mode>-<timestamp>/`.
 ---
 
 For routine DOM/text verification use the browser-validation skill — never mix tiers.
+
+> Edge-case scenarios (`--attach`, remote URL, SSH tunnel), Storybook URL, artifact formats, and env vars: [`docs/browser-validation.md`](../../../docs/browser-validation.md) · [`packages/browser-capture/README.md`](../../../packages/browser-capture/README.md)

--- a/.rulesync/skills/x-browser-capture/SKILL.md
+++ b/.rulesync/skills/x-browser-capture/SKILL.md
@@ -75,3 +75,5 @@ Artifacts land in `packages/browser-capture/artifacts/<mode>-<timestamp>/`.
 ---
 
 For routine DOM/text verification use the browser-validation skill — never mix tiers.
+
+> Edge-case scenarios (`--attach`, remote URL, SSH tunnel), Storybook URL, artifact formats, and env vars: [`docs/browser-validation.md`](../../../docs/browser-validation.md) · [`packages/browser-capture/README.md`](../../../packages/browser-capture/README.md)

--- a/.rulesync/skills/x-browser-capture/SKILL.md
+++ b/.rulesync/skills/x-browser-capture/SKILL.md
@@ -23,9 +23,7 @@ Exits 0 when live. URL is resolved automatically from `BUNDLER` in `.env`. Note 
 
 ## Step 2 — Pick capture tier
 
-Use attach only in visible Chrome to preserve session and tab state — not in CI. Run `pnpm browser open --url <url>` first.
-
-**Attach semantics:** match tab by URL **origin**; when several tabs share an origin, the most recently opened tab is used and brought to the front. Does not navigate. `record-console` with attach requires `url`. `record-trace` attach: HAR is capture-window only; `trace.zip` may include other tabs in the browser context.
+Use `--attach` only in visible Chrome (match by origin, no navigation) — not in CI. Run `pnpm browser open --url <url>` first. Capture attach: HAR is capture-window only; `trace.zip` may include other tabs; `record-console` needs a URL.
 
 ### A — `devtools-capture` MCP
 
@@ -77,5 +75,3 @@ Artifacts land in `packages/browser-capture/artifacts/<mode>-<timestamp>/`.
 ---
 
 For routine DOM/text verification use the browser-validation skill — never mix tiers.
-
-> Edge-case scenarios (`--attach`, remote URL, SSH tunnel), Storybook URL, artifact formats, and env vars: [`docs/browser-validation.md`](../../../docs/browser-validation.md) · [`packages/browser-capture/README.md`](../../../packages/browser-capture/README.md)

--- a/.rulesync/skills/x-browser-capture/SKILL.md
+++ b/.rulesync/skills/x-browser-capture/SKILL.md
@@ -25,6 +25,8 @@ Exits 0 when live. URL is resolved automatically from `BUNDLER` in `.env`. Note 
 
 Use attach only in visible Chrome to preserve session and tab state — not in CI. Run `pnpm browser open --url <url>` first.
 
+**Attach semantics:** match tab by URL **origin**; when several tabs share an origin, the most recently opened tab is used and brought to the front. Does not navigate. `record-console` with attach requires `url`. `record-trace` attach: HAR is capture-window only; `trace.zip` may include other tabs in the browser context.
+
 ### A — `devtools-capture` MCP
 
 Attach: `attach=true` on the tool.

--- a/.rulesync/skills/x-browser-capture/SKILL.md
+++ b/.rulesync/skills/x-browser-capture/SKILL.md
@@ -23,7 +23,7 @@ Exits 0 when live. URL is resolved automatically from `BUNDLER` in `.env`. Note 
 
 ## Step 2 — Pick capture tier
 
-Use `--attach` only in visible Chrome (match by origin, no navigation) — not in CI. Run `pnpm browser open --url <url>` first. Capture attach: HAR is capture-window only; `trace.zip` may include other tabs; `record-console` needs a URL.
+Attach: visible Chrome only, not CI. Match tab by origin; no navigation. Run `pnpm browser open --url <url>` first.
 
 ### A — `devtools-capture` MCP
 

--- a/docs/browser-validation.md
+++ b/docs/browser-validation.md
@@ -81,16 +81,10 @@ pnpm browser read --url <url> --selector "[data-testid=app-header]" --attach
 
 **`--attach` rules:**
 
-- Matches by **origin** (`scheme://host:port`) — any tab at that origin qualifies, regardless of path.
-- When multiple tabs share an origin, uses the **most recently opened** tab (last in CDP tab order), then calls `bringToFront()`.
-- Does **not** navigate — inspects whatever the tab currently shows.
-- Requires a tab open at that origin (`pnpm browser open` or manual navigation). Errors with a hint if none is found.
-- **Do not use in headless/CI/Cloud Agent** — each command should open a fresh isolated context there.
-
-**Capture-tier attach caveats** (`pnpm capture … --attach`):
-
-- `record-trace --attach`: `har.json` covers only traffic during the capture window; `trace.zip` is **browser-context** scoped (may include other tabs at any origin). See [`packages/browser-capture/README.md`](../packages/browser-capture/README.md).
-- `record-console --attach`: requires a URL (positional, `APP_URL`, or `CAPTURE_URL`) to match the tab by origin.
+- Match tab by **origin** only; does not navigate.
+- Multiple tabs at same origin → most recent (CDP order), brought to front.
+- Tab must already be open (`pnpm browser open`); not for CI/headless.
+- **Capture (`pnpm capture --attach`):** HAR = traffic during capture window only; `trace.zip` may include other tabs. `record-console --attach` requires a URL.
 
 ---
 

--- a/docs/browser-validation.md
+++ b/docs/browser-validation.md
@@ -82,9 +82,15 @@ pnpm browser read --url <url> --selector "[data-testid=app-header]" --attach
 **`--attach` rules:**
 
 - Matches by **origin** (`scheme://host:port`) — any tab at that origin qualifies, regardless of path.
+- When multiple tabs share an origin, uses the **most recently opened** tab (last in CDP tab order), then calls `bringToFront()`.
 - Does **not** navigate — inspects whatever the tab currently shows.
 - Requires a tab open at that origin (`pnpm browser open` or manual navigation). Errors with a hint if none is found.
 - **Do not use in headless/CI/Cloud Agent** — each command should open a fresh isolated context there.
+
+**Capture-tier attach caveats** (`pnpm capture … --attach`):
+
+- `record-trace --attach`: `har.json` covers only traffic during the capture window; `trace.zip` is **browser-context** scoped (may include other tabs at any origin). See [`packages/browser-capture/README.md`](../packages/browser-capture/README.md).
+- `record-console --attach`: requires a URL (positional, `APP_URL`, or `CAPTURE_URL`) to match the tab by origin.
 
 ---
 

--- a/packages/browser-capture/CHANGELOG.md
+++ b/packages/browser-capture/CHANGELOG.md
@@ -14,8 +14,10 @@ Newest phases first.
 
 - CLI `--attach` on `record-trace`, `record-performance`, `record-interactions`, `record-console`
 - Matches open tab by URL origin; does not navigate (preserves cookies and auth)
+- Tab selection: most recently opened tab at origin (CDP order) + `bringToFront()` via `@repo/browser-tools`
 - MCP: optional `attach` on `record_trace`, `record_performance`, `record_console`, `record_interactions`
 - Attach-mode HAR via `HarRecorder` (network activity during capture window only)
+- Documented attach caveats: capture-window HAR, browser-context `trace.zip`, `record-console` URL required
 
 #### Root wrapper & URL resolution
 

--- a/packages/browser-capture/README.md
+++ b/packages/browser-capture/README.md
@@ -72,7 +72,7 @@ Use `--attach` only in visible Chrome to preserve session and tab state — not 
 
 By default, navigate-based capture commands open a **new isolated browser context** (no cookies, no auth). Add `--attach` to record on the tab already open in the visible Chrome window — preserving its session, cookies, and current URL.
 
-`--attach` matches by **origin** (`scheme://host:port`) — any tab at that origin qualifies. The command does **not** navigate; it records whatever the tab currently shows. If no tab is found at that origin, the error hints to run `browser-tools open --url <url>` first.
+`--attach` matches by **origin** (`scheme://host:port`) — any tab at that origin qualifies. When multiple tabs share an origin, the **most recently opened** tab is used (last in CDP tab order) and brought to the front. The command does **not** navigate; it records whatever the tab currently shows. If no tab is found at that origin, the error hints to run `browser-tools open --url <url>` first.
 
 |                       | Default (no `--attach`)                       | `--attach`                                                                          |
 | --------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------- |

--- a/packages/browser-tools/src/cdp/__test__/session.test.js
+++ b/packages/browser-tools/src/cdp/__test__/session.test.js
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockBringToFront = vi.fn();
+const mockDetach = vi.fn();
+const mockClose = vi.fn(() => Promise.resolve());
+
+vi.mock('../connect.js', () => ({
+  connectOverCDP: vi.fn(),
+}));
+
+vi.mock('../console.js', () => ({
+  attachConsoleListeners: vi.fn(() => ({
+    pageErrors: [],
+    detach: mockDetach,
+  })),
+}));
+
+import { connectOverCDP } from '../connect.js';
+import { withAttachedSession } from '../session.js';
+
+describe('withAttachedSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('brings the matched page to front and detaches the console listener', async () => {
+    const page = {
+      bringToFront: mockBringToFront,
+      url: () => 'http://localhost:5173/',
+    };
+    const browser = {
+      contexts: () => [{ pages: () => [page] }],
+      close: mockClose,
+    };
+    connectOverCDP.mockResolvedValue(browser);
+
+    const result = await withAttachedSession(
+      'http://localhost:5173/',
+      async ({ page: matchedPage }) => {
+        expect(matchedPage).toBe(page);
+        return 'ok';
+      },
+    );
+
+    expect(result).toBe('ok');
+    expect(mockBringToFront).toHaveBeenCalledOnce();
+    expect(mockDetach).toHaveBeenCalledOnce();
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+
+  it('throws with an open hint when no tab matches the origin', async () => {
+    const browser = {
+      contexts: () => [{ pages: () => [] }],
+      close: mockClose,
+    };
+    connectOverCDP.mockResolvedValue(browser);
+
+    await expect(
+      withAttachedSession('http://localhost:5173/', async () => {}),
+    ).rejects.toThrow(/No open tab found/);
+
+    expect(mockClose).toHaveBeenCalledOnce();
+    expect(mockBringToFront).not.toHaveBeenCalled();
+  });
+});

--- a/packages/browser-tools/src/cdp/pages.js
+++ b/packages/browser-tools/src/cdp/pages.js
@@ -21,14 +21,11 @@ export async function findPageAtOrigin(browser, url) {
     return null;
   }
 
-  /** @type {Page | null} */
-  let match = null;
-
-  for (const context of browser.contexts()) {
-    for (const page of context.pages()) {
+  for (const context of [...browser.contexts()].reverse()) {
+    for (const page of [...context.pages()].reverse()) {
       try {
         if (new URL(page.url()).origin === origin) {
-          match = page;
+          return page;
         }
       } catch {
         // skip chrome://, about:blank, etc.
@@ -36,7 +33,7 @@ export async function findPageAtOrigin(browser, url) {
     }
   }
 
-  return match;
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Clarify `--attach` tab selection: `findPageAtOrigin` now walks CDP contexts/pages in reverse (most recently opened tab at origin), matching `bringToFront()` already called in `withAttachedSession`
- Add `withAttachedSession` unit tests (`bringToFront`, console detach, missing-tab error)
- Document capture-tier attach caveats in README, `browser-validation.md`, and the browser-capture skill (HAR capture-window only, browser-context `trace.zip`, `record-console` URL required)

Triage note: several items from the attach polish list were already fixed on `browser-capture` (console listener detach, HarRecorder keys, inject guards, MCP error handling, `record-console --attach` URL requirement). This PR covers the remaining doc + test + tab-selection clarity work.

## Test plan

- [x] `pnpm --filter @repo/browser-tools test`
- [x] `pnpm --filter @repo/browser-capture test`
- [ ] Manual: `pnpm browser open --url <dev-url>`, then `pnpm capture record-trace --attach --duration 3` on visible Chrome


Made with [Cursor](https://cursor.com)